### PR TITLE
Make a more specific exception

### DIFF
--- a/rncryptor.py
+++ b/rncryptor.py
@@ -72,7 +72,13 @@ Return True if the values are equal, False otherwise.
 """
 
 
-class DecryptionError(Exception):
+class RNCryptorError(Exception):
+    """Base error for when anything goes wrong with RNCryptor"""
+    pass
+
+
+class DecryptionError(RNCryptorError):
+    """Raised when bad data is inputted"""
     pass
 
 

--- a/rncryptor.py
+++ b/rncryptor.py
@@ -73,13 +73,19 @@ Return True if the values are equal, False otherwise.
 
 
 class RNCryptorError(Exception):
-    """Base error for when anything goes wrong with RNCryptor"""
-    pass
+    """Base error for when anything goes wrong with RNCryptor."""
+    def __init__(self, value):
+        self.value = value
+    def __str__(self):
+        return repr(self.value)
 
 
 class DecryptionError(RNCryptorError):
-    """Raised when bad data is inputted"""
-    pass
+    """Raised when bad data is inputted."""
+    def __init__(self, value):
+        self.value = value
+    def __str__(self):
+        return repr(self.value)
 
 
 class RNCryptor(object):

--- a/rncryptor.py
+++ b/rncryptor.py
@@ -74,18 +74,10 @@ Return True if the values are equal, False otherwise.
 
 class RNCryptorError(Exception):
     """Base error for when anything goes wrong with RNCryptor."""
-    def __init__(self, value):
-        self.value = value
-    def __str__(self):
-        return repr(self.value)
 
 
 class DecryptionError(RNCryptorError):
     """Raised when bad data is inputted."""
-    def __init__(self, value):
-        self.value = value
-    def __str__(self):
-        return repr(self.value)
 
 
 class RNCryptor(object):

--- a/rncryptor.py
+++ b/rncryptor.py
@@ -72,6 +72,10 @@ Return True if the values are equal, False otherwise.
 """
 
 
+class DecryptionError(Exception):
+    pass
+
+
 class RNCryptor(object):
     """Cryptor for RNCryptor."""
 
@@ -106,7 +110,7 @@ class RNCryptor(object):
         hmac_key = self._pbkdf2(password, hmac_salt)
 
         if not compare_in_constant_time(self._hmac(hmac_key, data[:n - 32]), hmac):
-            raise Exception("Bad data")
+            raise DecryptionError("Bad data")
 
         decrypted_data = self._aes_decrypt(encryption_key, iv, cipher_text)
 


### PR DESCRIPTION
I always wrap my RNCryptor code in a try, except clause, because bad data is somewhat commonplace in my program. It would be nice to be 100% certain that the exception is caused by bad data and handle accordingly, rather than the exception being handled as if it were bad data when it could be a variety of other problems. With this minor change, I can catch the DecryptionError instead of any generic Exception.