### PR TITLE
Python 3 compatibility: fix byte index access 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,7 @@ Usage
 
     # encrypt_with_keys and decrypt_with keys functions
     encryption_salt = '...' # 8 random bytes
+    hmac_salt = '...' # 8 random bytes
     encryption_key = rncryptor.make_key(password, encryption_salt)
     hmac_key = rncryptor.make_key(password, hmac_salt)
     encrypted_data = rncryptor.encrypt_with_keys(data, hmac_key, encryption_key)

--- a/rncryptor.py
+++ b/rncryptor.py
@@ -113,12 +113,12 @@ class RNCryptor(object):
             # data doesn't even match the required header + hmac length
             raise DecryptionError("Invalid length")
 
-        version = data[0]
+        version = data[:1]
         if not version == b'\x03':
             # required version is version 3
             raise DecryptionError("Unsupported version")
 
-        options = data[1]
+        options = data[1:2]
 
         if not options == b'\x01':
             # when using keys options should be `0`
@@ -153,13 +153,13 @@ class RNCryptor(object):
             # data doesn't even match the required header + hmac length
             raise DecryptionError("Invalid length")
 
-        version = data[0]
+        version = data[:1]
 
         if not version == b'\x03':
             # required version is version 3
             raise DecryptionError("Unsupported version")
 
-        options = data[1]
+        options = data[1:2]
 
         if not options == b'\x00':
             # when using keys options should be `0`


### PR DESCRIPTION
The current code only works correctly under Python 2.

Apparently in Python 3 it's not possible to use `data[1]` to access a byte, instead we have to use `data[1:2]`.

This pull request fixes this compatibility issue and it should still work correctly on both versions.